### PR TITLE
Prevent using package caching

### DIFF
--- a/jupyterlite_xeus/add_on.py
+++ b/jupyterlite_xeus/add_on.py
@@ -281,7 +281,7 @@ class XeusAddon(FederatedExtensionAddon):
             env_prefix=self.prefix,
             relocate_prefix="/",
             outdir=out_path,
-            use_cache=True,
+            use_cache=False,
             **pack_kwargs,
         )
 


### PR DESCRIPTION
This is known to cause issues with Python versions. Let's disable it for now and make it configurable in the future if needed.