### PR TITLE
JupyterLite-core 0.1.x support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "empack>=3.1,<4",
     "traitlets",
-    "jupyterlite-core>=0.2.0,<0.4",
+    "jupyterlite-core>=0.1,<0.4",
     "pyyaml",
     "requests",
 ]


### PR DESCRIPTION
Nothing prevents jupyterlite-xeus from working with jupyterlite-core 0.1.x so let's be nicer on the requirement 