### PR TITLE
Prevent failing when strict channel priority is set

### DIFF
--- a/jupyterlite_xeus/add_on.py
+++ b/jupyterlite_xeus/add_on.py
@@ -143,7 +143,7 @@ class XeusAddon(FederatedExtensionAddon):
                 env_name=env_name,
                 root_prefix=root_prefix,
                 specs=["xeus-python"],
-                channels=["conda-forge", "https://repo.mamba.pm/emscripten-forge"],
+                channels=["https://repo.mamba.pm/emscripten-forge", "conda-forge"],
             )
 
     def copy_kernels_from_prefix(self):

--- a/tests/environment-1.yml
+++ b/tests/environment-1.yml
@@ -1,7 +1,4 @@
 name: xeus-python-kernel-1
-channels:
-  - https://repo.mamba.pm/emscripten-forge
-  - conda-forge
 dependencies:
   - xeus-python
   - xeus-lua

--- a/tests/environment-2.yml
+++ b/tests/environment-2.yml
@@ -1,7 +1,4 @@
 name: xeus-python-kernel-2
-channels:
-  - https://repo.mamba.pm/emscripten-forge
-  - conda-forge
 dependencies:
   - xeus-python
   - pip:

--- a/tests/test_package/environment-3.yml
+++ b/tests/test_package/environment-3.yml
@@ -1,7 +1,4 @@
 name: xeus-python-kernel-3
-channels:
-  - https://repo.mamba.pm/emscripten-forge
-  - conda-forge
 dependencies:
   - xeus-python
   - numpy


### PR DESCRIPTION
When strict channel priority is being set, it seems specifying conda-forge first prevents the installation to work, because it tries to pull arch packages from conda-forge.

This PR puts emscripten-forge first by default.