### PR TITLE
Add `xeus-python` to the example `environment.yml` in the docs

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -76,6 +76,7 @@ channels:
   - https://repo.mamba.pm/emscripten-forge
   - conda-forge
 dependencies:
+  - xeus-python
   - numpy
   - pillow
   - ipywidgets
@@ -92,6 +93,7 @@ channels:
   - https://repo.mamba.pm/emscripten-forge
   - conda-forge
 dependencies:
+  - xeus-python
   - pip:
       - ..
 ```


### PR DESCRIPTION
In the "pip packages" section.

So users can more easily copy-paste the example `environment.yml`.