### PR TITLE
Fix order of kernels in UI tests

### DIFF
--- a/ui-tests/jupyter-lite.json
+++ b/ui-tests/jupyter-lite.json
@@ -2,6 +2,7 @@
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
     "appName": "JupyterLite UI Tests",
+    "defaultKernelName": "python",
     "exposeAppInBrowser": true
   }
 }

--- a/ui-tests/jupyter-lite.json
+++ b/ui-tests/jupyter-lite.json
@@ -2,7 +2,7 @@
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
     "appName": "JupyterLite UI Tests",
-    "defaultKernelName": "Lua",
+    "defaultKernelName": "xlua",
     "exposeAppInBrowser": true
   }
 }

--- a/ui-tests/jupyter-lite.json
+++ b/ui-tests/jupyter-lite.json
@@ -2,7 +2,7 @@
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
     "appName": "JupyterLite UI Tests",
-    "defaultKernelName": "lua",
+    "defaultKernelName": "Lua",
     "exposeAppInBrowser": true
   }
 }

--- a/ui-tests/jupyter-lite.json
+++ b/ui-tests/jupyter-lite.json
@@ -2,7 +2,7 @@
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
     "appName": "JupyterLite UI Tests",
-    "defaultKernelName": "python",
+    "defaultKernelName": "lua",
     "exposeAppInBrowser": true
   }
 }


### PR DESCRIPTION
Fixes https://github.com/jupyterlite/xeus/issues/83

Troubleshooting in https://github.com/jupyterlite/xeus/pull/84 didn't lead to explanations.

But setting the default kernel name explicitly might help.