### PR TITLE
Passing the link of empack_env_meta.json file

### DIFF
--- a/jupyterlite_xeus/add_on.py
+++ b/jupyterlite_xeus/add_on.py
@@ -293,12 +293,14 @@ class XeusAddon(FederatedExtensionAddon):
         else:
             pack_kwargs["file_filters"] = pkg_file_filter_from_yaml(DEFAULT_CONFIG_PATH)
 
+        if self.package_url_factory is not None:
+            pack_kwargs["package_url_factory"] = self.package_url_factory
+
         pack_env(
             env_prefix=self.prefix,
             relocate_prefix="/",
             outdir=out_path,
             use_cache=False,
-            package_url_factory=self.package_url_factory,
             **pack_kwargs,
         )
 
@@ -351,7 +353,8 @@ class XeusAddon(FederatedExtensionAddon):
         # Pack JupyterLite content if enabled
         # If we only build a voici output, mount jupyterlite content into the kernel by default
         if self.mount_jupyterlite_content or (
-            list(self.manager.apps) == ["voici"] and self.mount_jupyterlite_content is None
+            list(self.manager.apps) == ["voici"]
+            and self.mount_jupyterlite_content is None
         ):
             contents_dir = self.manager.output_dir / "files"
 

--- a/jupyterlite_xeus/add_on.py
+++ b/jupyterlite_xeus/add_on.py
@@ -1,4 +1,5 @@
 """a JupyterLite addon for creating the env for xeus kernels"""
+
 import json
 import os
 from pathlib import Path
@@ -18,7 +19,7 @@ from jupyterlite_core.constants import (
     SHARE_LABEXTENSIONS,
     UTF8,
 )
-from traitlets import Bool, List, Unicode
+from traitlets import Bool, Callable, List, Unicode
 
 from .create_conda_env import (
     create_conda_env_from_env_file,
@@ -100,6 +101,13 @@ class XeusAddon(FederatedExtensionAddon):
         [],
         config=True,
         description="A comma-separated list of mount points, in the form <host_path>:<mount_path> to mount in the wasm prefix",
+    )
+
+    package_url_factory = Callable(
+        None,
+        allow_none=True,
+        config=True,
+        description="Factory to generate package download URL from package metadata. This is used to load python packages from external host",
     )
 
     def __init__(self, *args, **kwargs):
@@ -290,6 +298,7 @@ class XeusAddon(FederatedExtensionAddon):
             relocate_prefix="/",
             outdir=out_path,
             use_cache=False,
+            package_url_factory=self.package_url_factory,
             **pack_kwargs,
         )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ const empackEnvMetaPlugin: JupyterLiteServerPlugin<IEmpackEnvMetaFile> = {
             PageConfig.getBaseUrl(),
             `xeus/kernels/${kernel}`
           );
-          return `${kernel_root_url}/empack_env_meta.json`;
+          return `${kernel_root_url}`;
       }
     };
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
   JupyterLiteServerPlugin
 } from '@jupyterlite/server';
 import { IBroadcastChannelWrapper } from '@jupyterlite/contents';
-import { IKernel, IKernelSpecs } from '@jupyterlite/kernel';
+import { IKernel, IKernelSpecs, IEmpackEnvMetaFile } from '@jupyterlite/kernel';
 
 import { WebWorkerKernel } from './web_worker_kernel';
 
@@ -34,12 +34,13 @@ const plugins = kernel_list.map((kernel): JupyterLiteServerPlugin<void> => {
     id: `@jupyterlite/xeus-${kernel}:register`,
     autoStart: true,
     requires: [IKernelSpecs],
-    optional: [IServiceWorkerManager, IBroadcastChannelWrapper],
+    optional: [IServiceWorkerManager, IBroadcastChannelWrapper, IEmpackEnvMetaFile],
     activate: (
       app: JupyterLiteServer,
       kernelspecs: IKernelSpecs,
       serviceWorker?: IServiceWorkerManager,
-      broadcastChannel?: IBroadcastChannelWrapper
+      broadcastChannel?: IBroadcastChannelWrapper,
+      empackEnvMetaFile?: IEmpackEnvMetaFile
     ) => {
       // Fetch kernel spec
       const kernelspec = getJson('xeus/kernels/' + kernel + '/kernel.json');
@@ -76,7 +77,8 @@ const plugins = kernel_list.map((kernel): JupyterLiteServerPlugin<void> => {
             ...options,
             contentsManager,
             mountDrive,
-            kernelSpec: kernelspec
+            kernelSpec: kernelspec,
+            empackEnvMetaLink:empackEnvMetaFile? empackEnvMetaFile.getLink(): ''
           });
         }
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ try {
   throw err;
 }
 
-const plugins = kernel_list.map((kernel): JupyterLiteServerPlugin<void> => {
+const plugins = kernel_list.map((kernel): JupyterLiteServerPlugin<void| IEmpackEnvMetaFile> => {
   return {
     id: `@jupyterlite/xeus-${kernel}:register`,
     autoStart: true,
@@ -73,13 +73,14 @@ const plugins = kernel_list.map((kernel): JupyterLiteServerPlugin<void> => {
               `${kernelspec.name} contents will NOT be synced with Jupyter Contents`
             );
           }
+          const link = empackEnvMetaFile ? await empackEnvMetaFile.getLink(): '';
 
           return new WebWorkerKernel({
             ...options,
             contentsManager,
             mountDrive,
             kernelSpec: kernelspec,
-            empackEnvMetaLink:empackEnvMetaFile? empackEnvMetaFile.getLink(): ''
+            empackEnvMetaLink: link
           });
         }
       });
@@ -87,13 +88,13 @@ const plugins = kernel_list.map((kernel): JupyterLiteServerPlugin<void> => {
   };
 });
 
-const empackEnvMetaPlugin: JupyterLiteServerPlugin<void> = {
+const empackEnvMetaPlugin: JupyterLiteServerPlugin<IEmpackEnvMetaFile> = {
   id: `@jupyterlite/xeus-python:empack-env-meta`,
   autoStart: true,
   provides: IEmpackEnvMetaFile,
   activate: (): IEmpackEnvMetaFile => {
     return {
-      getLink(){ 
+      getLink: async () => {
         let empackEnvMetaLink =''
          const searchParams = new URL(location.href).searchParams;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,7 @@ const plugins = kernel_list.map((kernel): JupyterLiteServerPlugin<void| IEmpackE
             );
           }
           const link = empackEnvMetaFile ? await empackEnvMetaFile.getLink(): '';
-          console.log('link');
-          console.log(link);
+
           return new WebWorkerKernel({
             ...options,
             contentsManager,

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,6 @@ const plugins = kernel_list.map((kernel): JupyterLiteServerPlugin<void| IEmpackE
       }
 
       const contentsManager = app.serviceManager.contents;
-
       kernelspecs.register({
         spec: kernelspec,
         create: async (options: IKernel.IOptions): Promise<IKernel> => {
@@ -74,7 +73,8 @@ const plugins = kernel_list.map((kernel): JupyterLiteServerPlugin<void| IEmpackE
             );
           }
           const link = empackEnvMetaFile ? await empackEnvMetaFile.getLink(): '';
-
+          console.log('link');
+          console.log(link);
           return new WebWorkerKernel({
             ...options,
             contentsManager,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,10 @@ import {
   JupyterLiteServerPlugin
 } from '@jupyterlite/server';
 import { IBroadcastChannelWrapper } from '@jupyterlite/contents';
-import { IKernel, IKernelSpecs, IEmpackEnvMetaFile } from '@jupyterlite/kernel';
+import { IKernel, IKernelSpecs } from '@jupyterlite/kernel';
 
 import { WebWorkerKernel } from './web_worker_kernel';
+import { IEmpackEnvMetaFile } from './tokens';
 
 function getJson(url: string) {
   const json_url = URLExt.join(PageConfig.getBaseUrl(), url);
@@ -85,5 +86,26 @@ const plugins = kernel_list.map((kernel): JupyterLiteServerPlugin<void> => {
     }
   };
 });
+
+const empackEnvMetaPlugin: JupyterLiteServerPlugin<void> = {
+  id: `@jupyterlite/xeus-python:empack-env-meta`,
+  autoStart: true,
+  provides: IEmpackEnvMetaFile,
+  activate: (): IEmpackEnvMetaFile => {
+    return {
+      getLink(){ 
+        let empackEnvMetaLink =''
+         const searchParams = new URL(location.href).searchParams;
+
+          if (searchParams && searchParams.get('empack_env_meta'))  {
+            empackEnvMetaLink = searchParams.get('empack_env_meta') as string;
+          }
+          return empackEnvMetaLink;
+      }
+    };
+  },
+};
+
+plugins.push(empackEnvMetaPlugin);
 
 export default plugins;

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ const plugins = kernel_list.map(
               );
             }
             const link = empackEnvMetaFile
-              ? await empackEnvMetaFile.getLink(kernelspec.dir)
+              ? await empackEnvMetaFile.getLink(kernelspec)
               : '';
 
             return new WebWorkerKernel({
@@ -101,10 +101,11 @@ const empackEnvMetaPlugin: JupyterLiteServerPlugin<IEmpackEnvMetaFile> = {
   provides: IEmpackEnvMetaFile,
   activate: (): IEmpackEnvMetaFile => {
     return {
-      getLink: async (kernel?: string) => {
+      getLink: async (kernelspec: Record<string, any>) => {
+        const kernelName = kernelspec.name;
         const kernel_root_url = URLExt.join(
           PageConfig.getBaseUrl(),
-          `xeus/kernels/${kernel}`
+          `xeus/kernels/${kernelName}`
         );
         return `${kernel_root_url}`;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ const plugins = kernel_list.map((kernel): JupyterLiteServerPlugin<void| IEmpackE
               `${kernelspec.name} contents will NOT be synced with Jupyter Contents`
             );
           }
-          const link = empackEnvMetaFile ? await empackEnvMetaFile.getLink(): '';
+          const link = empackEnvMetaFile ? await empackEnvMetaFile.getLink(kernelspec.dir): '';
 
           return new WebWorkerKernel({
             ...options,
@@ -93,14 +93,12 @@ const empackEnvMetaPlugin: JupyterLiteServerPlugin<IEmpackEnvMetaFile> = {
   provides: IEmpackEnvMetaFile,
   activate: (): IEmpackEnvMetaFile => {
     return {
-      getLink: async () => {
-        let empackEnvMetaLink =''
-         const searchParams = new URL(location.href).searchParams;
-
-          if (searchParams && searchParams.get('empack_env_meta'))  {
-            empackEnvMetaLink = searchParams.get('empack_env_meta') as string;
-          }
-          return empackEnvMetaLink;
+      getLink: async (kernel?: string) => {
+         const kernel_root_url = URLExt.join(
+            PageConfig.getBaseUrl(),
+            `xeus/kernels/${kernel}`
+          );
+          return `${kernel_root_url}/empack_env_meta.json`;
       }
     };
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ const plugins = kernel_list.map(
 );
 
 const empackEnvMetaPlugin: JupyterLiteServerPlugin<IEmpackEnvMetaFile> = {
-  id: '@jupyterlite/xeus-python:empack-env-meta',
+  id: '@jupyterlite/xeus:empack-env-meta',
   autoStart: true,
   provides: IEmpackEnvMetaFile,
   activate: (): IEmpackEnvMetaFile => {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -12,6 +12,7 @@ import {
 } from '@jupyterlite/contents';
 
 import { IWorkerKernel } from '@jupyterlite/kernel';
+import { Token } from '@lumino/coreutils';
 
 /**
  * An interface for Xeus workers.
@@ -88,3 +89,12 @@ export namespace IXeusWorkerKernel {
     empackEnvMetaLink?: string;
   }
 }
+
+export interface IEmpackEnvMetaFile {
+  /**
+   * Get empack_env_meta link.
+   */
+  getLink:()=> string;
+}
+
+export const IEmpackEnvMetaFile = new Token<IEmpackEnvMetaFile>('@jupyterlite/xeus-python:IEmpackEnvMetaFile');

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -97,4 +97,6 @@ export interface IEmpackEnvMetaFile {
   getLink: (kernel?: string) => Promise<string>;
 }
 
-export const IEmpackEnvMetaFile = new Token<IEmpackEnvMetaFile>('@jupyterlite/xeus-python:IEmpackEnvMetaFile');
+export const IEmpackEnvMetaFile = new Token<IEmpackEnvMetaFile>(
+  '@jupyterlite/xeus-python:IEmpackEnvMetaFile'
+);

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -94,7 +94,7 @@ export interface IEmpackEnvMetaFile {
   /**
    * Get empack_env_meta link.
    */
-  getLink:()=> string;
+  getLink: () => Promise<string>;
 }
 
 export const IEmpackEnvMetaFile = new Token<IEmpackEnvMetaFile>('@jupyterlite/xeus-python:IEmpackEnvMetaFile');

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -94,7 +94,7 @@ export interface IEmpackEnvMetaFile {
   /**
    * Get empack_env_meta link.
    */
-  getLink: () => Promise<string>;
+  getLink: (kernel?: string) => Promise<string>;
 }
 
 export const IEmpackEnvMetaFile = new Token<IEmpackEnvMetaFile>('@jupyterlite/xeus-python:IEmpackEnvMetaFile');

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -85,6 +85,6 @@ export namespace IXeusWorkerKernel {
     baseUrl: string;
     kernelSpec: any;
     mountDrive: boolean;
-    empack_env_meta_link: string;
+    empackEnvMetaLink?: string;
   }
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -98,5 +98,5 @@ export interface IEmpackEnvMetaFile {
 }
 
 export const IEmpackEnvMetaFile = new Token<IEmpackEnvMetaFile>(
-  '@jupyterlite/xeus-python:IEmpackEnvMetaFile'
+  '@jupyterlite/xeus:IEmpackEnvMetaFile'
 );

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -94,7 +94,7 @@ export interface IEmpackEnvMetaFile {
   /**
    * Get empack_env_meta link.
    */
-  getLink: (kernel?: string) => Promise<string>;
+  getLink: (kernelspec: Record<string, any>) => Promise<string>;
 }
 
 export const IEmpackEnvMetaFile = new Token<IEmpackEnvMetaFile>(

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -85,5 +85,6 @@ export namespace IXeusWorkerKernel {
     baseUrl: string;
     kernelSpec: any;
     mountDrive: boolean;
+    empack_env_meta_link: string;
   }
 }

--- a/src/web_worker_kernel.ts
+++ b/src/web_worker_kernel.ts
@@ -29,7 +29,7 @@ export class WebWorkerKernel implements IKernel {
    * @param options The instantiation options for a new WebWorkerKernel
    */
   constructor(options: WebWorkerKernel.IOptions) {
-    const { id, name, sendMessage, location, kernelSpec, contentsManager } =
+    const { id, name, sendMessage, location, kernelSpec, contentsManager, empackEnvMetaLink = '' } =
       options;
     this._id = id;
     this._name = name;
@@ -39,6 +39,7 @@ export class WebWorkerKernel implements IKernel {
     this._sendMessage = sendMessage;
     this._worker = this.initWorker(options);
     this._remoteKernel = this.initRemote(options);
+    this._empackEnvMetaLink = empackEnvMetaLink;
 
     this.initFileSystem(options);
   }
@@ -103,7 +104,8 @@ export class WebWorkerKernel implements IKernel {
       .initialize({
         kernelSpec: this._kernelSpec,
         baseUrl: PageConfig.getBaseUrl(),
-        mountDrive: options.mountDrive
+        mountDrive: options.mountDrive,
+        empackEnvMetaLink: this._empackEnvMetaLink,
       })
       .then(this._ready.resolve.bind(this._ready));
 
@@ -290,6 +292,7 @@ export class WebWorkerKernel implements IKernel {
     | undefined = undefined;
   private _parent: KernelMessage.IMessage | undefined = undefined;
   private _ready = new PromiseDelegate<void>();
+  private _empackEnvMetaLink: string;
 }
 
 /**
@@ -303,5 +306,6 @@ export namespace WebWorkerKernel {
     contentsManager: Contents.IManager;
     mountDrive: boolean;
     kernelSpec: any;
+    empackEnvMetaLink?: string;
   }
 }

--- a/src/web_worker_kernel.ts
+++ b/src/web_worker_kernel.ts
@@ -100,8 +100,6 @@ export class WebWorkerKernel implements IKernel {
       remote = wrap(this._worker) as Remote<IXeusWorkerKernel>;
     }
 
-    console.log('this._empackEnvMetaLink');
-    console.log(this._empackEnvMetaLink);
     remote
       .initialize({
         kernelSpec: this._kernelSpec,

--- a/src/web_worker_kernel.ts
+++ b/src/web_worker_kernel.ts
@@ -29,7 +29,7 @@ export class WebWorkerKernel implements IKernel {
    * @param options The instantiation options for a new WebWorkerKernel
    */
   constructor(options: WebWorkerKernel.IOptions) {
-    const { id, name, sendMessage, location, kernelSpec, contentsManager, empackEnvMetaLink = '' } =
+    const { id, name, sendMessage, location, kernelSpec, contentsManager, empackEnvMetaLink } =
       options;
     this._id = id;
     this._name = name;
@@ -100,6 +100,9 @@ export class WebWorkerKernel implements IKernel {
       };
       remote = wrap(this._worker) as Remote<IXeusWorkerKernel>;
     }
+    console.log('remote worker');
+    console.log('this._empackEnvMetaLink');
+    console.log(this._empackEnvMetaLink);
     remote
       .initialize({
         kernelSpec: this._kernelSpec,
@@ -292,7 +295,7 @@ export class WebWorkerKernel implements IKernel {
     | undefined = undefined;
   private _parent: KernelMessage.IMessage | undefined = undefined;
   private _ready = new PromiseDelegate<void>();
-  private _empackEnvMetaLink: string;
+  private _empackEnvMetaLink: string | undefined;
 }
 
 /**
@@ -306,6 +309,6 @@ export namespace WebWorkerKernel {
     contentsManager: Contents.IManager;
     mountDrive: boolean;
     kernelSpec: any;
-    empackEnvMetaLink?: string;
+    empackEnvMetaLink?: string | undefined;
   }
 }

--- a/src/web_worker_kernel.ts
+++ b/src/web_worker_kernel.ts
@@ -29,8 +29,15 @@ export class WebWorkerKernel implements IKernel {
    * @param options The instantiation options for a new WebWorkerKernel
    */
   constructor(options: WebWorkerKernel.IOptions) {
-    const { id, name, sendMessage, location, kernelSpec, contentsManager, empackEnvMetaLink } =
-      options;
+    const {
+      id,
+      name,
+      sendMessage,
+      location,
+      kernelSpec,
+      contentsManager,
+      empackEnvMetaLink
+    } = options;
     this._id = id;
     this._name = name;
     this._location = location;
@@ -105,7 +112,7 @@ export class WebWorkerKernel implements IKernel {
         kernelSpec: this._kernelSpec,
         baseUrl: PageConfig.getBaseUrl(),
         mountDrive: options.mountDrive,
-        empackEnvMetaLink: this._empackEnvMetaLink,
+        empackEnvMetaLink: this._empackEnvMetaLink
       })
       .then(this._ready.resolve.bind(this._ready));
 

--- a/src/web_worker_kernel.ts
+++ b/src/web_worker_kernel.ts
@@ -37,10 +37,9 @@ export class WebWorkerKernel implements IKernel {
     this._kernelSpec = kernelSpec;
     this._contentsManager = contentsManager;
     this._sendMessage = sendMessage;
+    this._empackEnvMetaLink = empackEnvMetaLink;
     this._worker = this.initWorker(options);
     this._remoteKernel = this.initRemote(options);
-    this._empackEnvMetaLink = empackEnvMetaLink;
-
     this.initFileSystem(options);
   }
 
@@ -100,7 +99,7 @@ export class WebWorkerKernel implements IKernel {
       };
       remote = wrap(this._worker) as Remote<IXeusWorkerKernel>;
     }
-    console.log('remote worker');
+
     console.log('this._empackEnvMetaLink');
     console.log(this._empackEnvMetaLink);
     remote

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -103,7 +103,7 @@ export class XeusRemoteKernel {
   }
 
   async initialize(options: IXeusWorkerKernel.IOptions): Promise<void> {
-    const { baseUrl, kernelSpec } = options;
+    const { baseUrl, kernelSpec, empack_env_meta_link } = options;
     // location of the kernel binary on the server
     const binary_js = URLExt.join(baseUrl, kernelSpec.argv[0]);
     const binary_wasm = binary_js.replace('.js', '.wasm');
@@ -134,7 +134,8 @@ export class XeusRemoteKernel {
         await globalThis.Module['async_init'](
           kernel_root_url,
           pkg_root_url,
-          verbose
+          verbose,
+          empack_env_meta_link
         );
       }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -103,7 +103,7 @@ export class XeusRemoteKernel {
   }
 
   async initialize(options: IXeusWorkerKernel.IOptions): Promise<void> {
-    const { baseUrl, kernelSpec, empack_env_meta_link } = options;
+    const { baseUrl, kernelSpec, empackEnvMetaLink } = options;
     // location of the kernel binary on the server
     const binary_js = URLExt.join(baseUrl, kernelSpec.argv[0]);
     const binary_wasm = binary_js.replace('.js', '.wasm');
@@ -131,6 +131,7 @@ export class XeusRemoteKernel {
         );
         const pkg_root_url = URLExt.join(baseUrl, 'xeus/kernel_packages');
         const verbose = true;
+        const empack_env_meta_link = empackEnvMetaLink;
         await globalThis.Module['async_init'](
           kernel_root_url,
           pkg_root_url,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -125,18 +125,16 @@ export class XeusRemoteKernel {
       // This function is usually implemented in the pre/post.js
       // in the emscripten build of that kernel
       if (globalThis.Module['async_init'] !== undefined) {
-        const kernel_root_url = URLExt.join(
+        const kernel_root_url = empackEnvMetaLink ? empackEnvMetaLink : URLExt.join(
           baseUrl,
           `xeus/kernels/${kernelSpec.dir}`
         );
         const pkg_root_url = URLExt.join(baseUrl, 'xeus/kernel_packages');
         const verbose = true;
-        const empack_env_meta_link = empackEnvMetaLink;
         await globalThis.Module['async_init'](
           kernel_root_url,
           pkg_root_url,
-          verbose,
-          empack_env_meta_link
+          verbose
         );
       }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -125,10 +125,9 @@ export class XeusRemoteKernel {
       // This function is usually implemented in the pre/post.js
       // in the emscripten build of that kernel
       if (globalThis.Module['async_init'] !== undefined) {
-        const kernel_root_url = empackEnvMetaLink ? empackEnvMetaLink : URLExt.join(
-          baseUrl,
-          `xeus/kernels/${kernelSpec.dir}`
-        );
+        const kernel_root_url = empackEnvMetaLink
+          ? empackEnvMetaLink
+          : URLExt.join(baseUrl, `xeus/kernels/${kernelSpec.dir}`);
         const pkg_root_url = URLExt.join(baseUrl, 'xeus/kernel_packages');
         const verbose = true;
         await globalThis.Module['async_init'](


### PR DESCRIPTION
This PR is the part of the solution of https://github.com/QuantStack/qs.ai/issues/28
 It includes next changes:
- a new plugin that takes `empack_env_meta` from search url params and this parameter contains a link where empack_env_meta.json file is hosted.
- This link is passed xeus-python during initialization of each kernel.

It should be used with https://github.com/emscripten-forge/pyjs/pull/74 together