### PR TITLE
Allow for JupyterLite 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "empack>=4.0.2,<6",
     "traitlets",
-    "jupyterlite-core>=0.1,<0.5",
+    "jupyterlite-core>=0.1,<0.6",
     "pyyaml",
     "requests",
 ]


### PR DESCRIPTION
Allow for installing `jupyterlite-xeus` with JupyterLite 0.5.0: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.5.0a0

There is currently no expected changes on the Python side of `jupyterlite-core`.