### PR TITLE
Remove xeus-r from docs for now

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - xeus-lua
   - xeus-javascript
   - xeus-nelson
-  - xeus-r
   - numpy
   - matplotlib
   - pillow


### PR DESCRIPTION
This breaks xeus-python. I'm reverting the addition to xeus-r to fix the docs for now. Will debug xeus-r later.