### PR TITLE
Enable Kernels to be built on top of kernlSpec arguments

### DIFF
--- a/packages/xeus/src/worker.ts
+++ b/packages/xeus/src/worker.ts
@@ -207,7 +207,7 @@ export abstract class XeusRemoteKernel {
       }
 
       this._initializeStdin(baseUrl, browsingContextId);
-
+      // backward compatibility: Checking if the kernel constructor takes argument or not
       rawXKernel = globalThis.Module.xkernel.length
         ? new globalThis.Module.xkernel(kernelSpec.argv)
         : new globalThis.Module.xkernel();


### PR DESCRIPTION
https://github.com/user-attachments/assets/f5ac6568-f2e2-4cfd-8db8-baf055fcd949


Demo above : Shows 3 xeus-cpp-lite kernels built (all use different flags `-std=c++17/20/23`)

On top of which xcpp20 is built using the -msimd128 flag (required for running xsimd in the browser)
```
  "argv": [
      "@XEUS_CPP_KERNELSPEC_PATH@xcpp",
      "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
      "-std=c++20", "-msimd128"
  ],
  
// instead of 

  "argv": [
      "@XEUS_CPP_KERNELSPEC_PATH@xcpp",
      "-resource-dir", "@XEUS_CPP_RESOURCE_DIR@",
      "-std=c++23", 
  ],
```

So xcpp20 kernel would work but xcpp23 wouldn't !

