### PR TITLE
Support stdin via service worker

### DIFF
--- a/packages/xeus/src/interfaces.ts
+++ b/packages/xeus/src/interfaces.ts
@@ -88,5 +88,6 @@ export namespace IXeusWorkerKernel {
     kernelSpec: any;
     mountDrive: boolean;
     empackEnvMetaLink?: string;
+    browsingContextId: string;
   }
 }

--- a/packages/xeus/src/web_worker_kernel.ts
+++ b/packages/xeus/src/web_worker_kernel.ts
@@ -113,7 +113,8 @@ export class WebWorkerKernel implements IKernel {
         kernelSpec: this._kernelSpec,
         baseUrl: PageConfig.getBaseUrl(),
         mountDrive: options.mountDrive,
-        empackEnvMetaLink: this._empackEnvMetaLink
+        empackEnvMetaLink: this._empackEnvMetaLink,
+        browsingContextId: options.browsingContextId
       })
       .then(this._ready.resolve.bind(this._ready));
 


### PR DESCRIPTION
This adds support for `stdin` requests using JupyterLite's service worker. It is part of the work of jupyterlite/jupyterlite#275 to support synchronous `stdin` across all JupyterLite kernels, and I have manually tested it locally with `xeus-cpp`, `xeus-python` and `xeus-r` kernels.

The changes here are not sufficient on their own, a JupyterLite PR is also required. I would like the changes here to be reviewed and merged and a pre-release made so that the JupyterLite PR can run CI against this.

Summary of changes:

1. Previously the `browsingContextId` was only used for shared filesystem access via the `IXeusWorkerKernel.mount` function. Now it is also needed for `stdin` requests so I am passing it to the kernel via the `WebWorkerKernel.IOptions`.
2. Setting `globalThis.get_stdin` was previously performed at the top of `worker.ts`. I have moved this to within `XeusRemoteKernel.initialize` and am using a closure as it needs access to both `baseUrl` and `browsingContextId`.
3. The implementation of `get_stdin` uses a synchronous `XMLHttpRequest`. This blocks the webworker until the input response is returned to it via the service worker.