### PR TITLE
Expose sendMessage to subclasses

### DIFF
--- a/packages/xeus/src/web_worker_kernel.ts
+++ b/packages/xeus/src/web_worker_kernel.ts
@@ -162,6 +162,13 @@ export class WebWorkerKernel implements IKernel {
   }
 
   /**
+   * Send kernel message to the client
+   */
+  protected get sendMessage(): IKernel.SendMessage {
+    return this._sendMessage;
+  }
+
+  /**
    * Process a message coming from the coincident web worker.
    *
    * @param msg The worker message to process.


### PR DESCRIPTION
This pull request introduces a new method to the `WebWorkerKernel` class in `packages/xeus/src/web_worker_kernel.ts` to expose the ability to send kernel messages to the client.

### Key Change:
* Added a protected getter `sendMessage` to the `WebWorkerKernel` class, which returns the `_sendMessage` property of type `IKernel.SendMessage`. This provides a way to send kernel messages to the client.