### PR TITLE
Support stdin via SharedArrayBuffer

### DIFF
--- a/packages/xeus/src/coincident.worker.ts
+++ b/packages/xeus/src/coincident.worker.ts
@@ -4,6 +4,8 @@
 
 import coincident from 'coincident';
 
+import type { KernelMessage } from '@jupyterlab/services';
+
 import {
   ContentsAPI,
   DriveFS,
@@ -67,7 +69,10 @@ export class XeusCoincidentKernel extends XeusRemoteKernel {
   }
 
   protected _initializeStdin(baseUrl: string, browsingContextId: string): void {
-    // TODO: SharedArrayBuffer implementation
+    globalThis.get_stdin = (
+      inputRequest: KernelMessage.IInputRequestMsg
+    ): KernelMessage.IInputReplyMsg =>
+      workerAPI.processStdinRequest(inputRequest);
   }
 }
 

--- a/packages/xeus/src/interfaces.ts
+++ b/packages/xeus/src/interfaces.ts
@@ -5,6 +5,8 @@
  * Definitions for the Xeus kernel.
  */
 
+import type { KernelMessage } from '@jupyterlab/services';
+
 import {
   TDriveMethod,
   TDriveRequest,
@@ -35,6 +37,15 @@ export interface IXeusWorkerKernel extends IWorkerKernel {
    * @param msg
    */
   processMessage(msg: any): void;
+
+  /**
+   * Process stdin request, blocking until the reply is received.
+   * This is sync for the web worker, async for the UI thread.
+   * @param inputRequest
+   */
+  processStdinRequest(
+    inputRequest: KernelMessage.IInputRequestMsg
+  ): KernelMessage.IInputReplyMsg;
 
   /**
    * Process worker message

--- a/packages/xeus/src/worker.ts
+++ b/packages/xeus/src/worker.ts
@@ -106,7 +106,8 @@ export abstract class XeusRemoteKernel {
     }
 
     if (msg_type === 'input_reply') {
-      // Should never be called as input_reply messages are returned via service worker
+      // Should never be called as input_reply messages are handled by get_stdin
+      // via SharedArrayBuffer or service worker.
     } else {
       rawXServer.notify_listener(event.msg);
     }


### PR DESCRIPTION
This PR adds support for `stdin` requests via `SharedArrayBuffer` using the `coincident` web worker. It follows similar work using a service worker (#212).

Here is a screencast using this with a local dev build of JupyterLite:

https://github.com/user-attachments/assets/e9880923-5591-4254-b5cc-b1abac55e432

It needs changes to JupyterLite to expose this functionality which I will submit soon along with the changes required for the service worker approach. The changes here also need to be ported to the pyodide kernel.