### PR TITLE
Add fallback for kernel constructor when argv is not accepted

### DIFF
--- a/packages/xeus/src/worker.ts
+++ b/packages/xeus/src/worker.ts
@@ -208,9 +208,11 @@ export abstract class XeusRemoteKernel {
 
       this._initializeStdin(baseUrl, browsingContextId);
       // backward compatibility: Checking if the kernel constructor takes argument or not
-      rawXKernel = globalThis.Module.xkernel.length
-        ? new globalThis.Module.xkernel(kernelSpec.argv)
-        : new globalThis.Module.xkernel();
+      try {
+        rawXKernel = new globalThis.Module.xkernel(kernelSpec.argv);
+      } catch (e) {
+        rawXKernel = new globalThis.Module.xkernel();
+      }
       rawXServer = rawXKernel.get_server();
       if (!rawXServer) {
         this._logger.error('Failed to start kernel!');


### PR DESCRIPTION
I attempted a fresh build for xeus-cpp and xeus-python through this and both work as expected. This should fix the wrongdoing introduced by https://github.com/jupyterlite/xeus/pull/210