### PR TITLE
Use `/api/stdin/kernel` for stdin requests via service worker

### DIFF
--- a/packages/xeus/src/comlink.worker.ts
+++ b/packages/xeus/src/comlink.worker.ts
@@ -50,7 +50,7 @@ export class XeusComlinkKernel extends XeusRemoteKernel {
       // the reply is received.
       try {
         const xhr = new XMLHttpRequest();
-        const url = URLExt.join(baseUrl, '/stdin/kernel');
+        const url = URLExt.join(baseUrl, '/api/stdin/kernel');
         xhr.open('POST', url, false); // Synchronous XMLHttpRequest
         const msg = JSON.stringify({
           browsingContextId,


### PR DESCRIPTION
Use `/api/stdin/kernel` for stdin requests via service worker insteasd of `/stdin/kernel` to work with latest changes in jupyterlite/jupyterlite#1640.