### PR TITLE
Separate deployment directory for each xeus environment

### DIFF
--- a/packages/xeus/src/worker.ts
+++ b/packages/xeus/src/worker.ts
@@ -337,12 +337,7 @@ export abstract class XeusRemoteKernel {
     const binary_js = URLExt.join(baseUrl, kernelSpec.argv[0]);
     const binary_wasm = binary_js.replace('.js', '.wasm');
     const binary_data = binary_js.replace('.js', '.data');
-    const kernel_root_url = URLExt.join(
-      baseUrl,
-      'xeus',
-      'kernels',
-      kernelSpec.dir
-    );
+    const kernel_root_url = URLExt.join(baseUrl, 'xeus', kernelSpec.envName);
 
     const sharedLibs =
       kernelSpec.metadata && kernelSpec.metadata.shared
@@ -353,7 +348,7 @@ export abstract class XeusRemoteKernel {
     globalThis.Module = await createXeusModule({
       locateFile: (file: string) => {
         if (file in sharedLibs) {
-          return URLExt.join(kernel_root_url, file);
+          return URLExt.join(kernel_root_url, kernelSpec.name, file);
         }
 
         if (file.endsWith('.wasm')) {
@@ -376,7 +371,7 @@ export abstract class XeusRemoteKernel {
         const packagesJsonUrl = `${empackEnvMetaLocation}/empack_env_meta.json`;
         this._pkgRootUrl = URLExt.join(
           baseUrl,
-          `xeus/kernels/${kernelSpec.name}/kernel_packages`
+          `xeus/${kernelSpec.envName}/kernel_packages`
         );
         this._empackEnvMeta = (await fetchJson(
           packagesJsonUrl

--- a/tests/environment-3.yml
+++ b/tests/environment-3.yml
@@ -1,0 +1,3 @@
+name: xeus-cpp-env
+dependencies:
+  - xeus-cpp

--- a/tests/test_xeus.py
+++ b/tests/test_xeus.py
@@ -24,27 +24,30 @@ def test_python_env_from_file_1():
         pass
 
     # Check env
-    assert os.path.isdir(addon.prefixes[0])
+    env_name = "xeus-python-kernel-1"
+    assert env_name in addon.prefixes
+    env_path = Path(addon.prefixes[env_name])
+    assert env_path.is_dir()
 
-    assert os.path.isfile(Path(addon.prefixes[0]) / "bin/xpython.js")
-    assert os.path.isfile(Path(addon.prefixes[0]) / "bin/xpython.wasm")
+    assert os.path.isfile(env_path / "bin/xpython.js")
+    assert os.path.isfile(env_path / "bin/xpython.wasm")
 
-    assert os.path.isfile(Path(addon.prefixes[0]) / "bin/xlua.js")
-    assert os.path.isfile(Path(addon.prefixes[0]) / "bin/xlua.wasm")
+    assert os.path.isfile(env_path / "bin/xlua.js")
+    assert os.path.isfile(env_path / "bin/xlua.wasm")
 
     # Checking pip packages
-    assert os.path.isdir(Path(addon.prefixes[0]) / "lib/python3.13")
-    assert os.path.isdir(Path(addon.prefixes[0]) / "lib/python3.13/site-packages")
-    assert os.path.isdir(Path(addon.prefixes[0]) / "lib/python3.13/site-packages/ipywidgets")
-    assert os.path.isdir(Path(addon.prefixes[0]) / "lib/python3.13/site-packages/ipycanvas")
-    assert os.path.isdir(Path(addon.prefixes[0]) / "lib/python3.13/site-packages/py2vega")
+    assert os.path.isdir(env_path / "lib/python3.13")
+    assert os.path.isdir(env_path / "lib/python3.13/site-packages")
+    assert os.path.isdir(env_path / "lib/python3.13/site-packages/ipywidgets")
+    assert os.path.isdir(env_path / "lib/python3.13/site-packages/ipycanvas")
+    assert os.path.isdir(env_path / "lib/python3.13/site-packages/py2vega")
 
     # Checking labextensions
     assert os.path.isdir(
-        Path(addon.prefixes[0])
+        env_path
         / "share/jupyter/labextensions/@jupyter-widgets/jupyterlab-manager"
     )
-    assert os.path.isdir(Path(addon.prefixes[0]) / "share/jupyter/labextensions/ipycanvas")
+    assert os.path.isdir(env_path / "share/jupyter/labextensions/ipycanvas")
 
 
 def test_python_env_from_file_3():
@@ -59,11 +62,16 @@ def test_python_env_from_file_3():
         pass
 
     # Test
+    env_name = "xeus-python-kernel-3"
+    assert env_name in addon.prefixes
+    env_path = Path(addon.prefixes[env_name])
+    assert env_path.is_dir()
+
     assert os.path.isdir(
-        Path(addon.prefixes[0]) / "lib/python3.13/site-packages/test_package"
+        env_path / "lib/python3.13/site-packages/test_package"
     )
     assert os.path.isfile(
-        Path(addon.prefixes[0]) / "lib/python3.13/site-packages/test_package/hey.py"
+        env_path / "lib/python3.13/site-packages/test_package/hey.py"
     )
 
 
@@ -95,7 +103,10 @@ def test_mount_point():
     for step in addon.post_build(manager):
         pass
 
-    outpath = Path(addon.cwd_name) / "packed_env" / "xpython"
+    env_name = "xeus-python-kernel-1"
+    assert env_name in addon.prefixes
+
+    outpath = Path(addon.cwd_name) / "packed_env" / env_name
 
     with tarfile.open(outpath / "mount_0.tar.gz", "r") as fobj:
         names = fobj.getnames()
@@ -104,3 +115,104 @@ def test_mount_point():
     with tarfile.open(outpath / "mount_1.tar.gz", "r") as fobj:
         names = fobj.getnames()
     assert "share/test_package/environment-3.yml" in names
+
+
+def test_multiple_envs_with_same_name_raises():
+    app = LiteStatusApp(log_level="DEBUG")
+    app.initialize()
+    manager = app.lite_manager
+
+    addon = XeusAddon(manager)
+    addon.environment_file = ["environment-3.yml", "environment-3.yml"]
+
+    with pytest.raises(ValueError):
+        for step in addon.post_build(manager):
+            pass
+
+
+def test_multiple_envs():
+    app = LiteStatusApp(log_level="DEBUG")
+    app.initialize()
+    manager = app.lite_manager
+
+    addon = XeusAddon(manager)
+    addon.environment_file = ["environment-1.yml", "environment-3.yml"]
+
+    # Store steps by name so can check locations copied to without actually copying.
+    steps = {}
+    for step in addon.post_build(manager):
+        steps[step["name"]] = step
+
+    env_name_py_lua = "xeus-python-kernel-1"
+    env_name_cpp = "xeus-cpp-env"
+    assert env_name_py_lua in addon.prefixes
+    assert env_name_cpp in addon.prefixes
+
+    env_path_py_lua = Path(addon.prefixes[env_name_py_lua])
+    env_path_cpp = Path(addon.prefixes[env_name_cpp])
+    assert env_path_py_lua.is_dir()
+    assert env_path_cpp.is_dir()
+
+    target_path = Path(__file__).parent / "_output" / "xeus"
+    keys = list(steps.keys())
+
+    # kernel.json (one per kernel)
+    action = steps[f"copy:{env_name_py_lua}:xpython:kernel.json"]["actions"][0][1]
+    assert action[1] == target_path / env_name_py_lua / "xpython" / "kernel.json"
+
+    action = steps[f"copy:{env_name_py_lua}:xlua:kernel.json"]["actions"][0][1]
+    assert action[1] == target_path / env_name_py_lua / "xlua" / "kernel.json"
+
+    action = steps[f"copy:{env_name_cpp}:xcpp20:kernel.json"]["actions"][0][1]
+    assert action[1] == target_path / env_name_cpp / "xcpp20" / "kernel.json"
+
+    # shared libraries
+    action = steps[f"copy:{env_name_cpp}:xcpp20:libclangCppInterOp.so"]["actions"][0][1]
+    assert action[1] == target_path / env_name_cpp / "xcpp20" / "libclangCppInterOp.so"
+
+    # binaries (one set per kernel)
+    actions = steps[f"copy:{env_name_py_lua}:xlua:binaries"]["actions"]
+    assert actions[0][1][1] == target_path / env_name_py_lua / "bin" / "xlua.js"
+    assert actions[1][1][1] == target_path / env_name_py_lua / "bin" / "xlua.wasm"
+
+    actions = steps[f"copy:{env_name_py_lua}:xpython:binaries"]["actions"]
+    assert actions[0][1][1] == target_path / env_name_py_lua / "bin" / "xpython.js"
+    assert actions[1][1][1] == target_path / env_name_py_lua / "bin" / "xpython.wasm"
+
+    actions = steps[f"copy:{env_name_cpp}:xcpp20:binaries"]["actions"]
+    assert actions[0][1][1] == target_path / env_name_cpp / "bin" / "xcpp.js"
+    assert actions[1][1][1] == target_path / env_name_cpp / "bin" / "xcpp.wasm"
+
+    # data (potentially one per kernel but only for xcpp here)
+    action = steps[f"copy:{env_name_cpp}:xcpp20:data"]["actions"][0][1]
+    assert action[1] == target_path / env_name_cpp / "bin" / "xcpp.data"
+
+    # empack_env_meta.json (one per env)
+    action = steps[f"xeus:{env_name_py_lua}:copy_env_file:empack_env_meta.json"]["actions"][0][1]
+    assert action[1] == target_path / env_name_py_lua / "empack_env_meta.json"
+
+    action = steps[f"xeus:{env_name_cpp}:copy_env_file:empack_env_meta.json"]["actions"][0][1]
+    assert action[1] == target_path / env_name_cpp / "empack_env_meta.json"
+
+    # kernel_packages (one directory per env)
+    ## packages that are in py_lua env but not cpp env
+    for pkg in ["xeus-lua-", "ipycanvas-"]:
+        match = list(filter(lambda k: k.startswith(f"xeus:{env_name_py_lua}:copy:{pkg}"), keys))
+        assert len(match) == 1
+        filename = match[0].split(':')[-1]  # e.g. xeus-lua-0.7.4-he62be5e_0.tar.gz
+        action = steps[match[0]]["actions"][0][1]
+        assert action[1] == target_path / env_name_py_lua / "kernel_packages" / filename
+
+        match = list(filter(lambda k: k.startswith(f"xeus:{env_name_cpp}:copy:{pkg}"), keys))
+        assert len(match) == 0
+
+    ## packages that are in cpp env but not py_lua env
+    for pkg in ["xeus-cpp-", "cppinterop-"]:
+        match = list(filter(lambda k: k.startswith(f"xeus:{env_name_py_lua}:copy:{pkg}"), keys))
+        assert len(match) == 0
+
+        match = list(filter(lambda k: k.startswith(f"xeus:{env_name_cpp}:copy:{pkg}"), keys))
+        assert len(match) == 1
+        filename = match[0].split(':')[-1]  # e.g. xeus-cpp-0.6.0-h18da88b_1.tar.gz
+        action = steps[match[0]]["actions"][0][1]
+        assert action[1] == target_path / env_name_cpp / "kernel_packages" / filename


### PR DESCRIPTION
This fixes #168 and is needed for #167.

When using `jupyter lite build` with an environment containing more than one `xeus` kernel, the kernel packages are unnecessarily duplicated. This PR changes the directory structure used to store `xeus` kernels so that each environment (from a `--XeusAddon.environment_file=<some env file name>`) is stored in a separate directory containing possibly multiple kernels, but the kernel packages are stored at the environment level rather than the kernel level.

Here is an illustration of the directory structure before and after this PR (not all the files are shown). It assumes two environments, `env-cpp` contains just an `xcpp20` kernel, and `env-py-r` contains `xpython` and `xr` kernels:
 
Before this PR (note there are 3 sets of `kernel_packages`):
```
📁 xeus
├── 📁 bin
│   ├── 📄 xcpp.{data,js,wasm}
│   ├── 📄 xpython.{data,js,wasm}
│   └── 📄 xr.{data,js,wasm}
├── 📁 kernels
│   ├── 📁 xcpp20
│   │   ├── 📄 empack_env_meta.json
│   │   ├── 📁 kernel_packages
│   │   │   └── 📄 xeus-cpp-whatever.tar.gz
│   │   ├── 📄 kernel.json
│   │   ├── 📄 libclangCppInterOp.so
│   │   └── 📄 logo-svg.svg
│   ├── 📁 xpython
│   │   ├── 📄 empack_env_meta.json
│   │   ├── 📁 kernel_packages
│   │   │   └── 📄 xeus-python-whatever.tar.gz
│   │   │   └── 📄 xeus-r-whatever.tar.gz
│   │   ├── 📄 kernel.json
│   │   └── 📄 logo-svg.svg
│   └── 📁 xr
│       ├── 📄 empack_env_meta.json
│       ├── 📁 kernel_packages
│       │   └── 📄 xeus-python-whatever.tar.gz
│       │   └── 📄 xeus-r-whatever.tar.gz
│       ├── 📄 kernel.json
│       ├── 📄 libRblas.so
│       ├── 📄 libRlapack.so
│       └── 📄 logo-svg.svg
└── 📄 kernels.json
```

After this PR (only 2 sets of `kernel_packages`):
```
📁 xeus
├── 📁 env-cpp
│   ├── 📁 bin
│   │   └── 📄 xcpp.{data,js,wasm}
│   ├── 📄 empack_env_meta.json
│   ├── 📁 kernel_packages
│   │   └── 📄 xeus-cpp-whatever.tar.gz
│   └── 📁 xcpp20
│   │   ├── 📄 kernel.json
│   │   ├── 📄 libclangCppInterOp.so
│   │   └── 📄 logo-svg.svg
├── 📁 env-py-r
│   ├── 📁 bin
│   │   ├── 📄 xpython.{data,js,wasm}
│   │   └── 📄 xr.{data,js,wasm}
│   ├── 📄 empack_env_meta.json
│   ├── 📁 kernel_packages
│   │   ├── 📄 xeus-python-whatever.tar.gz
│   │   └── 📄 xeus-r-whatever.tar.gz
│   ├── 📁 xpython
│   │   ├── 📄 kernel.json
│   │   └── 📄 logo-svg.svg
│   └── 📁 xr
│       ├── 📄 kernel.json
│       ├── 📄 libRblas.so
│       ├── 📄 libRlapack.so
│       └── 📄 logo-svg.svg
└── 📄 kernels.json
```
This also supports the storage of the same kernel in multiple environments, such as with different packages or a different kernel version, but these cannot yet be used. I'll add some comments to #167 on this.

I have made one design decision to change the format of the `kernels.json` file. Kernel name is no longer a unique identifier for a kernel, it is the combination of kernel name and environment name that is unique. So now `kernels.json` is no longer a list of kernel names but is a list of objects like `{ env_name: string, kernel: string }`. As `kernels.json` is only used internally within this project I think this is OK. The alternative is to keep the `kernels.json` as a list of strings but each string is `f"{kernel_name}/{env_name}"` which would need splitting up in the TypeScript code after it is read.

I've tested this manually using both `--environment_file` and `--prefix` options to `jupyter lite build`. I've also added some new unit tests.