### PR TITLE
Do not export comlink worker as part of the library

### DIFF
--- a/packages/xeus/src/index.ts
+++ b/packages/xeus/src/index.ts
@@ -1,5 +1,3 @@
-export * from './coincident.worker';
-export * from './comlink.worker';
 export * from './interfaces';
 export * from './web_worker_kernel';
 export * from './worker.base';


### PR DESCRIPTION
It seems we need to make a choice between exporting the comlink worker or going through webpack for it, but we cannot do both without conflicts with other tools like esbuild.