### PR TITLE
Install micromamba 2.0.5 in update-snapshots gha

### DIFF
--- a/.github/workflows/update-integration-tests.yml
+++ b/.github/workflows/update-integration-tests.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
+      - name: Install micromamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: xeus-lite-dev
+          micromamba-version: '2.0.5-0'
+
       - name: Install dependencies
         run: python -m pip install -U "jupyterlab>=4.4.0.b0,<5" jupyterlite-core
 


### PR DESCRIPTION
Install micromamba 2.0.5 in update-snapshots github action. The need for this was identified in #229, and we need it in `main` branch before we can check it works using the 'please update snapshots` comment.