### PR TITLE
Do not use refreshSpecs

### DIFF
--- a/packages/xeus-extension/src/index.ts
+++ b/packages/xeus-extension/src/index.ts
@@ -132,7 +132,11 @@ const kernelPlugin: JupyterFrontEndPlugin<void> = {
         }
       });
     }
-    await app.serviceManager.kernelspecs.refreshSpecs();
+
+    // @ts-expect-error: refreshSpecs() is not doing what it says it does, so we don't use it
+    await app.serviceManager.kernelspecs._specsChanged.emit(
+      app.serviceManager.kernelspecs.specs
+    );
 
     // Kernel logs
     if (loggerRegistry) {


### PR DESCRIPTION
The initial patch was removed and now relies on upstream jupyterlab's implementation, which seems to not be reliable enough for us?

https://github.com/jupyterlite/jupyterlite/pull/1596