### PR TITLE
Match real pip's error message for uninstalling non-installed pkg

### DIFF
--- a/packages/xeus/src/worker.ts
+++ b/packages/xeus/src/worker.ts
@@ -229,7 +229,9 @@ export abstract class EmpackedXeusRemoteKernel extends XeusRemoteKernelBase {
     specs.forEach((spec: string) => {
       const pkgName = packageNameFromSpec(spec);
       if (pkgName && !newInstalledPackagesMap[pkgName]) {
-        this.logger.log(`Package ${pkgName} is not in the installed list`);
+        this.logger.log(
+          `Failure: package to remove not found in the environment: ${pkgName}`
+        );
       } else {
         if (pkgName) {
           if (updatedCurrentSpecs[pkgName]) {
@@ -254,7 +256,7 @@ export abstract class EmpackedXeusRemoteKernel extends XeusRemoteKernelBase {
     pipSpecs.forEach((spec: string) => {
       const pkgName = packageNameFromSpec(spec);
       if (pkgName && !newInstalledPackagesMap[pkgName]) {
-        this.logger.log(`Package ${pkgName} is not in the installed list`);
+        this.logger.log(`WARNING: Skipping ${pkgName} as it is not installed.`);
       } else if (pkgName) {
         updatedInstalledPkgs = this.deleteFromInstalledPackages(
           pkgName,


### PR DESCRIPTION
Trying around our `%pip uninstall` magic alongside real pip, I saw the error message was slightly different for uninstall non-installed pkg. This PR fixes it, and does the same for conda.

![Screenshot From 2025-07-03 10-39-24](https://github.com/user-attachments/assets/662ab903-df60-4a1f-a18d-837090f77038)
