### PR TITLE
Allow for JupyterLite 0.7 pre-releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "empack>=5.1.1,<7",
     "traitlets",
-    "jupyterlite-core>=0.6,<0.7",
+    "jupyterlite-core>=0.6,<0.8.0a0",
     "pyyaml",
     "requests",
 ]


### PR DESCRIPTION
There is currently to breaking change that should impact `jupyterlite-xeus`, so maybe we can already bump the upper bound to allow for JupyterLite 0.7 pre-releases.
