### PR TITLE
Never dynamically load twice the same dynlib

### DIFF
--- a/packages/xeus/src/worker.ts
+++ b/packages/xeus/src/worker.ts
@@ -57,7 +57,7 @@ export abstract class EmpackedXeusRemoteKernel extends XeusRemoteKernelBase {
         : {};
 
     // Save .so files the kernel links against
-    Object.values(sharedLibs).forEach(this._kernelSharedLibs.add);
+    Object.values(sharedLibs).forEach(lib => this._kernelSharedLibs.add(lib));
     this._kernelSharedLibs.add('lib/libxeus.so');
 
     importScripts(binaryJS);


### PR DESCRIPTION
Prevent dynamically loading dynlibs that were already loaded by the kernel

--- 

Additionally for `libxeus.so`:

Loading it can only result in issues when the xeus version at runtime is incompatible with the one we built against.

Mitigate https://github.com/jupyterlite/xeus/issues/281 for now

Long term proper solution would be to:
- make all kernels use xeus shared on emscripten-forge?
- load only the shared libs that are required at runtime (for the next emscripten update on emscripten-forge)