### PR TITLE
Add xeus-octave to the list of supported kernels

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ The core feature of `jupyterlite-xeus` is its integration with [emscripten-forge
 
 Ideal for demos, educational resources, and offline computing. Use it in combination with [Voici](https://github.com/voila-dashboards/voici)!
 
-Currently supported kernels are:
+A non-exhaustive list of supported kernels:
 
 - [xeus-python](https://github.com/jupyter-xeus/xeus-python)
 - [xeus-lua](https://github.com/jupyter-xeus/xeus-lua)


### PR DESCRIPTION
Closes https://github.com/jupyterlite/xeus/issues/305

In a future pull request, we could add a new minimal working example tab for Octave like https://github.com/jupyterlite/xeus/blob/3e2025fcf8596aa5a82d4a7e0982e4292795e68f/docs/index.md?plain=1#L23-L44