### PR TITLE
Fix channels handling for !mamba install

### DIFF
--- a/packages/xeus/package.json
+++ b/packages/xeus/package.json
@@ -36,7 +36,7 @@
         "watch:src": "tsc -w --sourceMap"
     },
     "dependencies": {
-        "@emscripten-forge/mambajs": "^0.19.7",
+        "@emscripten-forge/mambajs": "^0.19.8",
         "@emscripten-forge/untarjs": "^5.3.2",
         "@jupyterlab/coreutils": "^6.5.0",
         "@jupyterlab/services": "^7.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,14 +84,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emscripten-forge/mambajs@npm:^0.19.7":
-  version: 0.19.7
-  resolution: "@emscripten-forge/mambajs@npm:0.19.7"
+"@emscripten-forge/mambajs@npm:^0.19.8":
+  version: 0.19.8
+  resolution: "@emscripten-forge/mambajs@npm:0.19.8"
   dependencies:
     "@conda-org/rattler": ^0.3.5
     "@emscripten-forge/mambajs-core": ^0.19.7
     yaml: ^2.7.0
-  checksum: f10e4abcc3940d3b34dd4a7fc839673fecf1f8d3043238cdd678aad2ebab7d89fb37184651aab8bdae5dcd7c9eccc82090510736299e848363c4a53a90afa6c3
+  checksum: 14a102d6d98f66bb2090a9fd5d560e6a76cf99ed92e20122579f4da91e3868b2c94cfdd2862e5d958f6908b6e04a301c403a562bafb15b4f13cdd04b6a3d010f
   languageName: node
   linkType: hard
 
@@ -853,7 +853,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlite/xeus@workspace:packages/xeus"
   dependencies:
-    "@emscripten-forge/mambajs": ^0.19.7
+    "@emscripten-forge/mambajs": ^0.19.8
     "@emscripten-forge/untarjs": ^5.3.2
     "@jupyterlab/coreutils": ^6.5.0
     "@jupyterlab/services": ^7.5.0


### PR DESCRIPTION
`!mamba install pkg` was always including default channels regardless of what was used for the environment already. This PR bumps mambajs to include the patch for that bug.

Fix issue mentioned in https://github.com/compiler-research/xeus-cpp/pull/416#issuecomment-3584272448