### PR TITLE
Handle mounted files

### DIFF
--- a/packages/xeus-core/src/web.worker.kernel.base.ts
+++ b/packages/xeus-core/src/web.worker.kernel.base.ts
@@ -231,7 +231,10 @@ export abstract class WebWorkerKernelBase implements IKernel {
       options.browsingContextId
     );
 
-    if (await this.remoteKernel.isDir('/files')) {
+    const filesLocalPath = `/files/${localPath}`;
+    if (localPath && (await this.remoteKernel.isDir(filesLocalPath))) {
+      await this.remoteKernel.cd(filesLocalPath);
+    } else if (await this.remoteKernel.isDir('/files')) {
       await this.remoteKernel.cd('/files');
     } else {
       await this.remoteKernel.cd(`/drive/${localPath}`);


### PR DESCRIPTION
More debugging of https://github.com/voila-dashboards/voici/pull/174

There seems to be an issue with how `mount_jupyterlite_content` is handled, which manifests itself in `voici` because of https://github.com/jupyterlite/xeus/blob/b1b05c511f70e44e4170038555810e04eb263201/jupyterlite_xeus/add_on.py#L495-L514