### PR TITLE
Working webbrowser module

### DIFF
--- a/packages/xeus-core/src/web.worker.kernel.base.ts
+++ b/packages/xeus-core/src/web.worker.kernel.base.ts
@@ -73,6 +73,14 @@ export abstract class WebWorkerKernelBase implements IKernel {
 
   protected processWorkerMessage(msg: any) {
     if (!msg.header) {
+      // Special handling for pyjs's webbrowser module
+      // Allows:
+      // import webbrowser; webbrowser.open('https://google.com')
+      if (msg.OPEN_TAB) {
+        const { url } = msg.OPEN_TAB;
+        window.open(url)?.focus();
+      }
+
       // Custom msg bypassing comlink/coincident protocol
       if (msg._stream) {
         const parentHeaderValue = this.parentHeader;

--- a/packages/xeus-extension/src/index.ts
+++ b/packages/xeus-extension/src/index.ts
@@ -144,7 +144,7 @@ const kernelPlugin: JupyterFrontEndPlugin<void> = {
     if (loggerRegistry) {
       const channel = new BroadcastChannel('/xeus-kernel-logs-broadcast');
 
-      channel.onmessage = event => {
+      channel.addEventListener('message', event => {
         const { kernelId, payload } = event.data as {
           kernelId: string;
           payload: ILogPayload;
@@ -163,7 +163,7 @@ const kernelPlugin: JupyterFrontEndPlugin<void> = {
 
         const logger = loggerRegistry.getLogger(sessionPath);
         logger.log(payload);
-      };
+      });
     }
   }
 };

--- a/packages/xeus/src/web.worker.kernel.ts
+++ b/packages/xeus/src/web.worker.kernel.ts
@@ -57,9 +57,9 @@ export class WebWorkerKernel extends WebWorkerKernelBase {
 
     // We directly forward messages to xeus, which will dispatch them properly
     // See discussion in https://github.com/jupyterlite/xeus/pull/108#discussion_r1750143661
-    this.worker.onmessage = e => {
+    this.worker.addEventListener('message', e => {
       this.processWorkerMessage(e.data);
-    };
+    });
 
     if (crossOriginIsolated) {
       remote = coincident(this.worker) as IEmpackXeusWorkerKernel;


### PR DESCRIPTION
Once pyjs is updated with https://github.com/emscripten-forge/pyjs/pull/122, we'll get a working webbrowser module

```python
from webbrowser import open
open('https://google.com')
```